### PR TITLE
Supports referencing other components

### DIFF
--- a/src/visitors/taggedTemplateExpressionVisitor.js
+++ b/src/visitors/taggedTemplateExpressionVisitor.js
@@ -27,9 +27,13 @@ export default (path, state, {types: t}) => {
             if (!source) return;
             p.isClean = true;
 
-            const raw = transpileLess(source, state.file.opts.filename);
-            if (source !== raw) {
-                p.replaceWithSourceString('`' + raw + '`');
+            try {
+                const raw = transpileLess(source, state.file.opts.filename);
+                if (source !== raw) {
+                    p.replaceWithSourceString('`' + raw + '`');
+                }
+            } catch (e) {
+                console.error("Error converting the less syntax", e);
             }
         },
     });

--- a/test/Component/StyledComponent.test.js
+++ b/test/Component/StyledComponent.test.js
@@ -70,7 +70,7 @@ test('Support @media queries', () => {
 test('Support &&&', () => {
     const Div = styled.div`
         &&& {
-            color: palevioletred; 
+            color: palevioletred;
             font-weight: @bold;
         }
         &&&second {
@@ -91,4 +91,29 @@ test('Support Element', () => {
         }
 	`;
     expect(renderer.create(<Div/>).toJSON()).toMatchSnapshot();
+});
+
+test('Support placeholder on the root', () => {
+    const Div = styled.div`
+        &::placeholder {
+            color: HSL(216, 15%, 65%);
+        }
+	`;
+    expect(renderer.create(<Div/>).toJSON()).toMatchSnapshot();
+});
+
+test('Support styling other components', () => {
+    const Child1 = styled.div`
+        color: brown;
+	`;
+    const Child2 = styled.div`
+        color: red;
+	`;
+    const Div = styled.div`
+        ${Child1},
+        ${Child2}{
+            width: 400px;
+        }
+	`;
+    expect(renderer.create(<Div><Child1/><Child2/></Div>).toJSON()).toMatchSnapshot();
 });

--- a/test/Component/__snapshots__/StyledComponent.test.js.snap
+++ b/test/Component/__snapshots__/StyledComponent.test.js.snap
@@ -100,6 +100,54 @@ exports[`Support Element 1`] = `
 />
 `;
 
+exports[`Support placeholder on the root 1`] = `
+.c0::-webkit-input-placeholder {
+  color: #98a3b3ff;
+}
+
+.c0::-moz-placeholder {
+  color: #98a3b3ff;
+}
+
+.c0:-ms-input-placeholder {
+  color: #98a3b3ff;
+}
+
+.c0::placeholder {
+  color: #98a3b3ff;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`Support styling other components 1`] = `
+.c2 {
+  color: brown;
+}
+
+.c4 {
+  color: red;
+}
+
+.c0 .c1,
+.c0 .c3 {
+  width: 400px;
+}
+
+<div
+  className="c0"
+>
+  <div
+    className="c1 c2"
+  />
+  <div
+    className="c3 c4"
+  />
+</div>
+`;
+
 exports[`Support the styled-components css 1`] = `
 .c0 {
   padding: 1rem;


### PR DESCRIPTION
This block now works:
```
    const Child1 = styled.div`
        color: brown;
	`;
    const Child2 = styled.div`
        color: red;
	`;
    const Div = styled.div`
        ${Child1},
        ${Child2}{
            width: 400px;
        }
	`;
```